### PR TITLE
Feature/return_gt

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,26 @@ print(anls)
 
 4. Thats it!
 
+### Returning the closest match
+The `anls_score` function can also be used to return the object which best matches the prediction and can be derived from the ground truth by re-ordering lists, selecting options from tuples etc. by setting the `return_gt` argument to `True` (default is `False`).
+
+As an example:
+```python
+gt = {'a': ('hello', 'world'), 'b': ['this', 'is', 'a', 'test']}
+pred = {'a': 'hello!', 'b': ['a', 'test', 'this', 'be']}
+score, closest_gt = anls_score(gt, pred, return_gt=True)
+# score = 0.766...
+# closest_gt = {'a': 'hello', 'b': ['a', 'test', 'this', 'is']}
+```
+
+This result can then be used e.g. with the [deepdiff](https://pypi.org/project/deepdiff/) package for further analysis:
+```python
+from deepdiff import DeepDiff
+diff = DeepDiff(closest_gt, pred)
+# diff = {'values_changed': {"root['a']": {'new_value': 'hello!', 'old_value': 'hello'},
+#                            "root['b'][3]": {'new_value': 'be', 'old_value': 'is'}}}
+```
+
 ## Supported Types
 Simply copy this file to your project and import the `anls_score` function from it. Then call the function with the ground truth and the predictions. 
 

--- a/src/anls_star.py
+++ b/src/anls_star.py
@@ -322,10 +322,12 @@ def anls_score(
 
 
 @overload
-def anls_score(gt: Any, pred: Any, *, return_gt: bool = False) -> float: ...
+def anls_score(
+    gt: Any, pred: Any, *, return_gt: bool = False
+) -> Union[float, tuple[float, Any]]: ...
 
 
-def anls_score(gt, pred, *, return_gt=False) -> Union[float, tuple[float, Any]]:
+def anls_score(gt, pred, *, return_gt=False):
     """Run ANLS on a ground truth and prediction object. The returned score is a value between 0 and 1, where 1 is the best possible score. For further information on the ANLS metric and the types see https://arxiv.org/
 
     Types of gt and pred:

--- a/src/anls_star.py
+++ b/src/anls_star.py
@@ -327,7 +327,7 @@ def anls_score(
 ) -> Union[float, tuple[float, Any]]: ...
 
 
-def anls_score(gt, pred):
+def anls_score(gt, pred, return_gt: bool = False):
     """Run ANLS on a ground truth and prediction object. The returned score is a value between 0 and 1, where 1 is the best possible score. For further information on the ANLS metric and the types see https://arxiv.org/abs/2402.03848
 
     Types of gt and pred:

--- a/src/anls_star.py
+++ b/src/anls_star.py
@@ -342,9 +342,19 @@ def anls_score(gt, pred, return_gt: bool = False):
     Args:
         gt: The ground truth object. Can be a string, list, tuple, dict, or any combination of those. See type descriptions above.
         pred: The prediction object - usually the output of the model. Can be a string, list, tuple, dict, or any combination of those. See type descriptions above.
+        return_gt: If `True`, the function also returns the object that best matches the prediction, and can be derived from the ground truth (i.e. selecting options from tuples, reordering lists, etc.). This is useful for debugging and error analysis.
+
 
     Returns:
-        The ANLS score [0-1]
+        - The ANLS score [0-1] if `return_gt` is `False`.
+        - A tuple with the ANLS score [0-1] and the closest ground truth object if `return_gt` is `True`.
+
+    Examples:
+        >>> gt = {'a': ('hello', 'world'), 'b': ['this', 'is', 'a', 'test']}
+        >>> pred = {'a': 'hello!', 'b': ['a', 'test', 'this', 'be']}
+        >>> score, closest_gt = anls_score(gt, pred, return_gt=True)
+        # score = 0.766...
+        # closest_gt = {'a': 'hello', 'b': ['a', 'test', 'this', 'is']}
     """
 
     # Convert gt list to tuple in order to be compatible with classical QA datasets

--- a/src/anls_star.py
+++ b/src/anls_star.py
@@ -8,6 +8,7 @@ DeepOpinion, 2024
 """
 
 import abc
+import math
 import warnings
 from typing import Any, Literal, Union, overload
 
@@ -138,7 +139,11 @@ class ANLSList(ANLSTree):
                 nls_list, chosen_gt = gt.nls_list(pred)
                 length = gt.pairwise_len(pred)
                 row.append(nls_list)
-                avg_row.append((sum(nls_list) / length) if length > 0 else 1.0)
+                avg = (sum(nls_list) / length) if length > 0 else 1.0
+                if pred.obj == chosen_gt:
+                    # Slightly favor exact matches to break ties in the Hungarian algorithm
+                    avg = math.nextafter(avg, float("inf"))
+                avg_row.append(avg)
                 gts_row.append(chosen_gt)
             mat.append(row)
             avg_mat.append(avg_row)


### PR DESCRIPTION
Adds optional return of "closest ground truth". This returns the ground truth in a format that is equivalent to the original object, but as close as possible to the prediction. For example, multi-option tuples are reduced to the best match, lists and dicts are reordered to match the prediction, and None-values are replaced by equivalent falsy values, if such a value was predicted