### PR TITLE
[BUILD] Fix `py.typed` marker and bump to `1.0.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 ### Removed
 
 
+## Release v1.0.1 (2026-01-12)
+### Fixed
+- `py.typed` needs to be included in the release as well.
+
+
 ## Release v1.0.0 (2026-01-07)
 ### Added
 - `ruff` for sorting of imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "anls_star"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   { name="Otera", email="hello@otera.ai" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "anls-star"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "munkres" },


### PR DESCRIPTION
## ✨ Changes Overview
<!-- Please list changes with bullet points -- typically more detailed and technical than the changelog -->
- Fix `py.typed` marker and bump to `1.0.1`

## ✅ Mandatory Checklist
<!-- Must be completed before merging -->
- [x] PR description provides a list of changes made
- [x] PR title uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) with upper case letters, e.g. `[FEAT]`, `[FIX]`, `[CI]`, or a combination like `[REFACTOR/FIX]`. Use `!` for breaking changes (e.g., `[!CHORE]`).

## 💡 Optional Checklist
<!-- Check if applicable, otherwise leave unchecked -->
- [ ] Fixes # <!-- issue number (closes the related issue automatically upon merging) -->
- [ ] Related to JIRA ticket: <!-- reference to ticket -->
- [x] `CHANGELOG.md` has been updated
- [ ] Added or updated tests to cover the changes introduced by this PR
- [ ] Tests are passing locally  <!-- run `uv run pytest` locally to verify -->
